### PR TITLE
Add children to the scene separately from self.children

### DIFF
--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 // @flow
+
+// $FlowFixMe
 import * as THREE from 'three';
 import TrackballControls from './controls/TrackballControls.js';
 

--- a/src/layers/AxisLayer.js
+++ b/src/layers/AxisLayer.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 // @flow
 
+// $FlowFixMe
 import * as THREE from 'three/build/three.min';
 import Layer from '../Layer';
 

--- a/src/layers/AxisLayer.js
+++ b/src/layers/AxisLayer.js
@@ -27,8 +27,8 @@ export default class AxisLayer extends Layer {
 
     requestInit(scene : Object) {
         let self = this;
-        self.children.push(
-            scene.add(new THREE.AxesHelper(5))
-        );
+        let axes = new THREE.AxesHelper(5);
+        self.children.push(axes);
+        scene.add(axes);
     }
 }

--- a/src/layers/LightingLayer.js
+++ b/src/layers/LightingLayer.js
@@ -30,14 +30,17 @@ export default class LightingLayer extends Layer {
         // Key
         let key = new THREE.PointLight(0xfff, 1, 100);
         key.position.set(-5, -5, 5);
-        self.children.push(scene.add(key));
+        self.children.push(key);
+        scene.add(key);
         // Fill
         let fill = new THREE.PointLight(0xccc, 0.7, 100);
         fill.position.set(5, -5, 4);
-        self.children.push(scene.add(fill));
+        self.children.push(fill);
+        scene.add(fill);
         // Back
         let back = new THREE.PointLight(0xccc, 0.65, 100);
         back.position.set(-5, 5, 3);
-        self.children.push(scene.add(back));
+        self.children.push(back);
+        scene.add(back);
     }
 }

--- a/src/layers/LightingLayer.js
+++ b/src/layers/LightingLayer.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 // @flow
 
+// $FlowFixMe
 import * as THREE from 'three';
 import Layer from '../Layer';
 

--- a/src/layers/LineSegmentsLayer.js
+++ b/src/layers/LineSegmentsLayer.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 // @flow
 
+// $FlowFixMe
 import * as THREE from 'three';
 import Layer from '../Layer';
 

--- a/src/layers/MeshLayer.js
+++ b/src/layers/MeshLayer.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// $FlowFixMe
 import * as THREE from 'three';
 import Layer from '../Layer';
 import OBJLoader from '../loaders/OBJLoader';

--- a/src/layers/VolumeLayer.js
+++ b/src/layers/VolumeLayer.js
@@ -39,7 +39,7 @@ void main() {
 }
 `;
 
-
+// $FlowFixMe
 import * as THREE from 'three/build/three.min';
 import Layer from '../Layer';
 

--- a/src/layers/VolumeLayer.js
+++ b/src/layers/VolumeLayer.js
@@ -116,6 +116,7 @@ export default class VolumeLayer extends Layer {
 
         let particleSystem = new THREE.Points(geometry, shaderMaterial);
 
+        self.children.push(particleSystem);
         scene.add(particleSystem);
     }
 }


### PR DESCRIPTION
This fixes the bug where calling .removeLayer fails on some prim-type layers.